### PR TITLE
Create infrastructure using Terraform

### DIFF
--- a/src/iac/main.tf
+++ b/src/iac/main.tf
@@ -1,0 +1,121 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-q2a-demo-uksouth-001"
+  location = "uksouth"
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "vnet-q2a-demo-uksouth-001"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "subnet-q2a-demo-uksouth-001"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "pip" {
+  name                = "pip-q2a-demo-uksouth-001"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "nic-q2a-demo-uksouth-001"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.pip.id
+  }
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "nsg-q2a-demo-uksouth-001"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "RDP"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "3389"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "nsg_association" {
+  network_interface_id      = azurerm_network_interface.nic.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+resource "azurerm_virtual_machine" "vm" {
+  name                  = "vm-q2a-demo-uksouth-001"
+  location              = azurerm_resource_group.rg.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.nic.id]
+  vm_size               = "Standard_DS1_v2"
+
+  storage_os_disk {
+    name              = "osdisk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = "vm-q2a-demo-uksouth-001"
+    admin_username = "azureuser"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}


### PR DESCRIPTION
Fixes #1

Add `main.tf` file to provision required infrastructure using Terraform.

* **Resource Group**: Define a resource group named `rg-q2a-demo-uksouth-001`.
* **Virtual Network**: Define a virtual network named `vnet-q2a-demo-uksouth-001` with an address space of `10.0.0.0/16`.
* **Subnet**: Define a subnet named `subnet-q2a-demo-uksouth-001` with an address prefix of `10.0.1.0/24`.
* **Public IP Address**: Define a public IP address named `pip-q2a-demo-uksouth-001` with a static allocation method.
* **Network Interface**: Define a network interface named `nic-q2a-demo-uksouth-001` with an IP configuration.
* **Network Security Group**: Define a network security group named `nsg-q2a-demo-uksouth-001` with security rules for SSH (22), RDP (3389), and HTTP (80).
* **Network Interface Security Group Association**: Associate the network interface with the network security group.
* **Virtual Machine**: Define a virtual machine named `vm-q2a-demo-uksouth-001` with a standard DS1_v2 size, Ubuntu 18.04-LTS image, and necessary OS profile configurations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DevOpsVisions/copilot-workspace-demo/issues/1?shareId=e38acaf8-91f4-4be1-b5da-2f677cc30e3c).