### PR TITLE
Amend Terraform configuration to execute shell script

### DIFF
--- a/src/iac/main.tf
+++ b/src/iac/main.tf
@@ -118,4 +118,15 @@ resource "azurerm_virtual_machine" "vm" {
   os_profile_linux_config {
     disable_password_authentication = false
   }
+
+  provisioner "remote-exec" {
+    connection {
+      type        = "ssh"
+      user        = "azureuser"
+      password    = "Password1234!"
+      host        = azurerm_public_ip.pip.ip_address
+    }
+
+    script = "install-lamp.sh"
+  }
 }


### PR DESCRIPTION
Fixes #3

Update Terraform configuration to execute shell script during infrastructure setup.

* Add a `provisioner "remote-exec"` block to the `azurerm_virtual_machine` resource in `src/iac/main.tf`.
* Use the `connection` block to specify SSH access details for the VM.
* Reference the `install-lamp.sh` script in the `remote-exec` provisioner.
* Ensure the script is executed after the VM is provisioned.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DevOpsVisions/copilot-workspace-demo/issues/3?shareId=2af2b954-6d96-49dc-b273-8abaeb876b11).