### PR TITLE
Create GitHub Actions workflow for Azure Terraform infrastructure provisioning

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,35 @@
+name: Terraform Azure Deployment
+
+on: workflow_dispatch
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v2
+
+      - name: 'Set up Terraform'
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.0
+
+      - name: Authenticate with Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: 'Terraform Init'
+        run: terraform init
+        working-directory: ./src/iac
+
+      - name: 'Terraform Apply'
+        run: terraform apply -auto-approve
+        working-directory: ./src/iac
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}


### PR DESCRIPTION
Fixes #4

Add a GitHub Actions workflow for provisioning infrastructure on Azure using Terraform.

* **Workflow Configuration:**
  - Create a new workflow file `.github/workflows/terraform.yml`.
  - Set the workflow name to "Terraform Azure Deployment".
  - Trigger the workflow on `workflow_dispatch`.

* **Job Definition:**
  - Define a job named `terraform` that runs on `ubuntu-latest`.

* **Steps:**
  - Checkout the repository using `actions/checkout@v2`.
  - Set up Terraform using `hashicorp/setup-terraform@v1` with version 1.0.0.
  - Authenticate with Azure using `azure/login@v1` with credentials from `secrets.AZURE_CREDENTIALS`.
  - Initialize Terraform in the `./src/iac` directory.
  - Apply the Terraform configuration in the `./src/iac` directory with auto-approve, using Azure environment variables from secrets.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DevOpsVisions/copilot-workspace-demo/issues/4?shareId=fc37b079-1f61-4118-aa66-87698a59dfc8).